### PR TITLE
Simplify API regarding 'VERSION' and 'REQUIRES'

### DIFF
--- a/src/cicd_sim/git/branch.py
+++ b/src/cicd_sim/git/branch.py
@@ -65,8 +65,31 @@ class Branch:
     def get_version(self):
         return self.get_file_content('VERSION')
 
+    def set_version(self, version):
+        """Set the project version
+
+        :version: A string denoting a semver.org version. E.g. '1.2.3-pre.0+20200313'
+        
+        Technically, this function commits a file named 'VERSION' as this CICD
+        simulator expects an according file to determine the project version.
+        """
+        return self.commit_file('VERSION', version)
+
     def get_requires(self):
         return self.get_file_content('REQUIRES')
+
+    def set_requires(self, requires):
+        """Set the project requires (AKA dependencies)
+
+        :requires: A string composed of the required package and the required 
+        semver version or version range delimited by a slash ('/'). 
+        E.g. 'lib/1.2.4', 'libA/1.x' or even 'lib/>1.0.0.0-0 <2.0.0'
+        
+        Technically, this function commits a file named 'REQUIRES' as this CICD
+        simulator expects an according file to determine the projects 
+        requirements.
+        """
+        return self.commit_file('REQUIRES', requires)
 
     def get_file_content(self, file_name):
         return self._files.get_file_content(file_name)

--- a/src/simple_lib_app.py
+++ b/src/simple_lib_app.py
@@ -11,10 +11,10 @@ app = github.create_repo('app', jenkins)
 
 # Start developing
 lib_dev = lib.create_branch('develop', 'blue')
-lib_dev.commit_file('VERSION', '1.0.1')
+lib_dev.set_version('1.0.1')
 lib_dev.push()
 
 app_dev = app.create_branch('develop', 'blue')
-app_dev.commit_file('VERSION', '1.0.0')
-app_dev.commit_file('REQUIRES', 'lib/1.x')
+app_dev.set_version('1.0.0')
+app_dev.set_requires('lib/1.x')
 app_dev.push()

--- a/tests/buildmachine/test_jenkins.py
+++ b/tests/buildmachine/test_jenkins.py
@@ -25,8 +25,8 @@ class TestJenkins(unittest.TestCase):
 
     def _get_or_create_branch(self, branch_name, version, requires = ''):
         branch = self._repo.checkout(branch_name)
-        branch.commit_file('VERSION', version)
-        return branch.commit_file('REQUIRES', requires)
+        branch.set_version(version)
+        return branch.set_requires(requires)
 
     def test_build_develop(self):
         self._build_id_generator.generate_id = MagicMock(return_value = "theBuildId")
@@ -81,11 +81,11 @@ class TestJenkins(unittest.TestCase):
         jenkins = self._create_jenkins(artifactory)
 
         lib_repo = self._repos.create_repo('lib', jenkins)
-        lib = lib_repo.checkout('develop').commit_file('VERSION', '1.0.1')
+        lib = lib_repo.checkout('develop').set_version('1.0.1')
         lib.push()
 
         app_repo = self._repos.create_repo('app', jenkins)
-        app = app_repo.checkout('develop').commit_file('VERSION', '1.0.1').commit_file('REQUIRES', 'lib/1.x')
+        app = app_repo.checkout('develop').set_version('1.0.1').set_requires('lib/1.x')
         app.push()
 
         # Expect a rebuild of 'app' because a new artifact for 'lib' will be created
@@ -97,9 +97,9 @@ class TestJenkins(unittest.TestCase):
         jenkins = self._create_jenkins()
 
         lib_repo = self._repos.create_repo('lib', jenkins)
-        lib_repo.checkout('master').commit_file('VERSION', '1.0.1')
+        lib_repo.checkout('master').set_version('1.0.1')
 
         app_repo = self._repos.create_repo('app', jenkins)
-        app = app_repo.checkout('master').commit_file('VERSION', '1.0.1').commit_file('REQUIRES', 'lib/1.x')
+        app = app_repo.checkout('master').set_version('1.0.1').set_requires('lib/1.x')
         # conan install should fail with exception
         self.assertRaises(Exception, lambda: app.push())

--- a/tests/conan/test_conan.py
+++ b/tests/conan/test_conan.py
@@ -13,10 +13,10 @@ class TestConan(unittest.TestCase):
         self._repos = Repos()
 
     def _create_test_library(self):
-        return self._repos.create_repo('lib', {}).checkout('master').commit_file('REQUIRES', '')
+        return self._repos.create_repo('lib', {}).checkout('master').set_requires('')
 
     def _create_test_app(self):
-        return self._repos.create_repo('app', {}).checkout('master').commit_file('VERSION', '6.0.0')
+        return self._repos.create_repo('app', {}).checkout('master').set_version('6.0.0')
 
     def _create_conan(self, output = NullOutput()):
         return Conan(output)
@@ -38,7 +38,7 @@ class TestConan(unittest.TestCase):
             'lib': ['1.2.3']
         }
         app_branch = self._create_test_app()
-        app_branch.commit_file('REQUIRES', 'lib/1.x')
+        app_branch.set_requires('lib/1.x')
         resolved_packages, requires = self._create_conan().resolve_requires(artifacts, app_branch)
         self.assertEqual('lib/1.2.3', resolved_packages)
         self.assertEqual(('lib', '1.x'), requires)
@@ -48,7 +48,7 @@ class TestConan(unittest.TestCase):
             'lib': ['2.2.3']
         }
         app_branch = self._create_test_app()
-        app_branch.commit_file('REQUIRES', 'lib/1.x')
+        app_branch.set_requires('lib/1.x')
         resolved_packages, requires = self._create_conan().resolve_requires(artifacts, app_branch)
         self.assertIsNone(resolved_packages)
         self.assertEqual(('lib', '1.x'), requires)
@@ -56,13 +56,13 @@ class TestConan(unittest.TestCase):
     def test_check_requires_requires_syntax_error(self):
         lib = self._repos.create_repo('lib', {})
         branch = lib.checkout('master')
-        branch.commit_file('REQUIRES', 'invalid | format')
+        branch.set_requires('invalid | format')
         conan = self._create_conan()
         self.assertRaises(Exception, lambda: conan._determine_requires(branch))
 
     def test_conan_install(self):
         app_branch = self._create_test_app()
-        app_branch.commit_file('REQUIRES', 'lib/2.x')
+        app_branch.set_requires('lib/2.x')
         artifacts = {
             'lib': ['2.0.3']
         }
@@ -124,7 +124,7 @@ conan_install_test_values = [
 
 @pytest.mark.parametrize("require_version, versions, expected_version", conan_install_test_values)
 def test_conan_install_parametrized(require_version, versions, expected_version):
-    app_branch = Repos().create_repo('lib', {}).checkout('master').commit_file('REQUIRES', require_version)
+    app_branch = Repos().create_repo('lib', {}).checkout('master').set_requires(require_version)
     artifacts = {
         'lib': versions
     }

--- a/tests/git/test_branch.py
+++ b/tests/git/test_branch.py
@@ -66,7 +66,7 @@ class TestGitBranch(unittest.TestCase):
     def test_chaining(self):
         buildmachine = MagicMock()
         repo = self._create_repo(buildmachine)
-        branch = repo.checkout('master').commit_file('VERSION', '1.2.3')
+        branch = repo.checkout('master').set_version('1.2.3')
         self.assertEqual(repo.checkout('master'), branch)
 
     def test_create_branch__new_color(self):


### PR DESCRIPTION
Provide specific functions to set a projects version and it's requirements. This should make usage more obvious to the user