### PR TITLE
Simplified API

### DIFF
--- a/notebooks/example1.ipynb
+++ b/notebooks/example1.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lib = bitbucket.create_repo('lib', jenkins)\n",
+    "lib = bitbucket.create_repo('lib')\n",
     "lib_dev = lib.create_branch('develop', 'blue')\n",
     "lib_dev.commit_file('VERSION', '1.0.0')\n",
     "lib_dev.push()"
@@ -79,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app = bitbucket.create_repo('app', jenkins)\n",
+    "app = bitbucket.create_repo('app')\n",
     "app_dev = app.create_branch('develop', 'magenta')\n",
     "app_dev.commit_file('VERSION', '1.0.0')\n",
     "app_dev.commit_file('REQUIRES', 'lib/>1.0.0-0')\n",
@@ -256,20 +256,6 @@
     "lib_r125.delete()\n",
     "lib_master.push()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/cicd_sim/buildmachine/jenkins.py
+++ b/src/cicd_sim/buildmachine/jenkins.py
@@ -13,6 +13,10 @@ class Jenkins:
         self._output = output
         self._build_id_generator = build_id_generator
         self._remember_built_branches = {}
+        self._register_build_hooks()
+    
+    def _register_build_hooks(self):
+        self._repos.set_buildmachine(self)
        
     def build(self, branch):
         """Build a Git branch.

--- a/src/cicd_sim/git/repo.py
+++ b/src/cicd_sim/git/repo.py
@@ -6,11 +6,11 @@ from . sha import SHA
 class Repo:
     """A "Repo" is a single Git repo
     """
-    def __init__(self, name, buildmachine):
+    def __init__(self, name, repos):
         self._branches = []
         self._sha = SHA()
         self._name = name
-        self._buildmachine = buildmachine
+        self._repos = repos
         self._create_default_branch()
 
     def __repr__(self):
@@ -20,7 +20,7 @@ class Repo:
         return self._sha.generate_next()
 
     def push(self, branch):
-        self._buildmachine.build(branch)
+        self._repos.trigger_buildmachine(branch)
 
     def get_name(self):
         return self._name

--- a/src/cicd_sim/git/repos.py
+++ b/src/cicd_sim/git/repos.py
@@ -7,14 +7,21 @@ class Repos:
     """
     def __init__(self):
         self._repos = []
+        self._buildmachine = None
 
-    def create_repo(self, project_name, buildmachine):
+    def set_buildmachine(self, buildmachine):
+        self._buildmachine = buildmachine
+
+    def create_repo(self, project_name):
         repo = self._find_repo(project_name)
         if repo is None:
-            repo = Repo(project_name, buildmachine)
+            repo = Repo(project_name, self)
             self._repos.append(repo)
         return repo
     
+    def trigger_buildmachine(self, branch):
+        self._buildmachine.build(branch)
+
     def get_repos(self):
         return self._repos
 

--- a/src/simple_lib_app.py
+++ b/src/simple_lib_app.py
@@ -6,8 +6,8 @@ artifactory = Artifactory()
 jenkins = Jenkins(artifactory, github)
 
 # Create Git repos/projects
-lib = github.create_repo('lib', jenkins)
-app = github.create_repo('app', jenkins)
+lib = github.create_repo('lib')
+app = github.create_repo('app')
 
 # Start developing
 lib_dev = lib.create_branch('develop', 'blue')

--- a/tests/buildmachine/test_jenkins.py
+++ b/tests/buildmachine/test_jenkins.py
@@ -12,7 +12,7 @@ class TestJenkins(unittest.TestCase):
 
     def setUp(self):
         self._repos = Repos()
-        self._repo = self._repos.create_repo('theRepo', {})
+        self._repo = self._repos.create_repo('theRepo')
         self._build_id_generator = BuildIdGenerator()
 
     def _create_jenkins(self, artifactory = Artifactory()):
@@ -80,11 +80,11 @@ class TestJenkins(unittest.TestCase):
         artifactory = Artifactory()
         jenkins = self._create_jenkins(artifactory)
 
-        lib_repo = self._repos.create_repo('lib', jenkins)
+        lib_repo = self._repos.create_repo('lib')
         lib = lib_repo.checkout('develop').set_version('1.0.1')
         lib.push()
 
-        app_repo = self._repos.create_repo('app', jenkins)
+        app_repo = self._repos.create_repo('app')
         app = app_repo.checkout('develop').set_version('1.0.1').set_requires('lib/1.x')
         app.push()
 
@@ -96,10 +96,10 @@ class TestJenkins(unittest.TestCase):
     def test_push_app__before_lib_available__conan_install_should_fail(self):
         jenkins = self._create_jenkins()
 
-        lib_repo = self._repos.create_repo('lib', jenkins)
+        lib_repo = self._repos.create_repo('lib')
         lib_repo.checkout('master').set_version('1.0.1')
 
-        app_repo = self._repos.create_repo('app', jenkins)
+        app_repo = self._repos.create_repo('app')
         app = app_repo.checkout('master').set_version('1.0.1').set_requires('lib/1.x')
         # conan install should fail with exception
         self.assertRaises(Exception, lambda: app.push())

--- a/tests/conan/test_conan.py
+++ b/tests/conan/test_conan.py
@@ -13,10 +13,10 @@ class TestConan(unittest.TestCase):
         self._repos = Repos()
 
     def _create_test_library(self):
-        return self._repos.create_repo('lib', {}).checkout('master').set_requires('')
+        return self._repos.create_repo('lib').checkout('master').set_requires('')
 
     def _create_test_app(self):
-        return self._repos.create_repo('app', {}).checkout('master').set_version('6.0.0')
+        return self._repos.create_repo('app').checkout('master').set_version('6.0.0')
 
     def _create_conan(self, output = NullOutput()):
         return Conan(output)
@@ -54,7 +54,7 @@ class TestConan(unittest.TestCase):
         self.assertEqual(('lib', '1.x'), requires)
 
     def test_check_requires_requires_syntax_error(self):
-        lib = self._repos.create_repo('lib', {})
+        lib = self._repos.create_repo('lib')
         branch = lib.checkout('master')
         branch.set_requires('invalid | format')
         conan = self._create_conan()
@@ -124,7 +124,7 @@ conan_install_test_values = [
 
 @pytest.mark.parametrize("require_version, versions, expected_version", conan_install_test_values)
 def test_conan_install_parametrized(require_version, versions, expected_version):
-    app_branch = Repos().create_repo('lib', {}).checkout('master').set_requires(require_version)
+    app_branch = Repos().create_repo('lib').checkout('master').set_requires(require_version)
     artifacts = {
         'lib': versions
     }

--- a/tests/git/test_branch.py
+++ b/tests/git/test_branch.py
@@ -13,7 +13,8 @@ class TestGitBranch(unittest.TestCase):
 
     def _create_repo(self, buildmachine):
         repos = Repos()
-        return repos.create_repo(self._project_name, buildmachine)
+        repos.set_buildmachine(buildmachine)
+        return repos.create_repo(self._project_name)
 
     def test_default_branch(self):
         branch = Branch('develop', self._repo)

--- a/tests/git/test_repo.py
+++ b/tests/git/test_repo.py
@@ -26,12 +26,12 @@ class TestGitRepo(unittest.TestCase):
         self.assertIsInstance(sha, str)
 
     def test_push_a_branch(self):
-        buildmachine = MagicMock()
-        buildmachine.build = MagicMock()
+        repos = MagicMock()
+        repos.trigger_buildmachine = MagicMock()
         branch = 'The Branch'
-        repo = self._createRepo('a name', buildmachine)
+        repo = self._createRepo('a name', repos)
         repo.push(branch)
-        buildmachine.build.assert_called_with('The Branch')
+        repos.trigger_buildmachine.assert_called_with('The Branch')
 
     def test_create_branch(self):
         repo = self._createRepo()

--- a/tests/git/test_repos.py
+++ b/tests/git/test_repos.py
@@ -9,19 +9,19 @@ class TestGitRepos(unittest.TestCase):
         self._repos = Repos()
 
     def test_create_repo(self):
-        repo = self._repos.create_repo("ProjectName", {})
+        repo = self._repos.create_repo("ProjectName")
         self.assertIn(repo, self._repos.get_repos())
 
     def test_no_repos_after_creation(self):
         self.assertEqual(0, len(self._repos.get_repos()))
 
     def test_create_two_repos(self):
-        repo1 = self._repos.create_repo("Prj1", {})
-        repo2 = self._repos.create_repo("Prj2", {})
+        repo1 = self._repos.create_repo("Prj1")
+        repo2 = self._repos.create_repo("Prj2")
         self.assertIn(repo1, self._repos.get_repos())
         self.assertIn(repo2, self._repos.get_repos())
 
     def test_create_repo_that_already_exists__expect__return_existing(self):
-        repo1 = self._repos.create_repo('repo', {})
-        repo2 = self._repos.create_repo('repo', {})
+        repo1 = self._repos.create_repo('repo')
+        repo2 = self._repos.create_repo('repo')
         self.assertEqual(repo1, repo2)


### PR DESCRIPTION
When creating a new repository, the buildmachine doesn't need to be specified anymore since there's only ever one buildmachine per Git repo service (in this simulator)